### PR TITLE
Changing Antora version tag for main branch to snapshot

### DIFF
--- a/src/docs/antora.yml
+++ b/src/docs/antora.yml
@@ -1,6 +1,6 @@
 name: bamm-specification
 title: BAMM Aspect Meta Model
-version: '1.0-RC1'
+version: 'snapshot'
 start_page: ROOT:index.adoc
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
This changes the Antora version tag for BAMM on the main branch to snapshot. For each release this attribute will be set to the corresponding version on the release branch.