### PR TITLE
Modify HEADER template in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,9 +149,10 @@ The header should follow the following template:
 Copyright (c) {YEAR} {NAME OF COMPANY X} 
 Copyright (c) {YEAR} {NAME OF COMPANY Y} 
 
-See the AUTHORS file(s) distributed with this work for additional
-information regarding authorship.
+See the AUTHORS file(s) distributed with this work for additional information regarding authorship. 
 
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/
 SPDX-License-Identifier: MPL-2.0
 ////
 ```


### PR DESCRIPTION
The header template from the CONTRIBUTING.md is missing two lines that where already applied to the existing files in the repository.
This commit adds these two lines to the template to align it.