### PR TITLE
Correct wrong BAMM acronym

### DIFF
--- a/src/docs/modules/ROOT/pages/namespaces.adoc
+++ b/src/docs/modules/ROOT/pages/namespaces.adoc
@@ -57,7 +57,7 @@ where the variable parts are interpreted as follows:
 
 * *namespace* -- Defines the hierarchical namespace in which the element resides. This is given in
    https://en.wikipedia.org/wiki/Reverse_domain_name_notation[Reverse Domain Name Notation]. To
-   avoid confusion with the The Bosch Aspect Meta Model, this _should not_ be equal to
+   avoid confusion with the BAMM Aspect Meta Model, this _should not_ be equal to
    `org.open-manufacturing.digitaltwin`.
 * *version* -- The version of the respective namespace, must be given in the form "X.Y.Z", with X, Y
    and Z being integers.


### PR DESCRIPTION
The commit replaces a wrong usage of the BAMM acronym.