### PR TITLE
Enable release builds

### DIFF
--- a/.github/workflows/antora-build.yml
+++ b/.github/workflows/antora-build.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2.3.1
+      with:
+        ref: main
+        fetch-depth: '0'
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:


### PR DESCRIPTION
This PR enables release builds by ensuring that the ref is pointing to the main branch but all branches are fetched.