### PR TITLE
Add v to release branch name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ name of branch | description
 ----| ----
 `main` | Contains the latest state of the repository
 `v{version_number}-RC` | A state on which the working group agreed on as a release candidate but which is missing the approval by the OMP. 
-{version_number} | A release of the respective version which is approved by the working group and the OMP. 
+`v{version_number}` | A release of the respective version which is approved by the working group and the OMP. 
 `feature/{feature-name}` | Contains the development on a specific feature and is intended to be merged back into the `main` branch as soon as possible. Note, that it is recommended for contributors to create and develop feature branches in a personal fork and not the upstream repository.
 
 ## Issues


### PR DESCRIPTION
This PR adds a prepended v to the release branch name.
Closes #17