### PR TITLE
Proper repository licence detection by GitHub

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,5 +10,6 @@ The following people have contributed to this repository:
 * Andreas Schilling, andreas.schilling3@de.bosch.com
 * Georg Schmidt-Dumont, Robert Bosch GmbH, georg.schmidt-dumont@de.bosch.com 
 * Andreas Textor, Andreas.Textor@de.bosch.com
+* Dominic Schabel
 
 Please add yourself to this list, if you contribute to the content.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -226,13 +226,10 @@ distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location 
 (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
 
-Copyright (c) 2020 Robert Bosch GmbH
+You may add additional accurate notices of copyright ownership.
 
 Exhibit B - “Incompatible With Secondary Licenses” Notice
 This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
 
----- Additional notices on copyright according to Exhibit A ----
-
-Copyright (c) 2020 Robert Bosch Manufacturing Solutions GmbH, all rights reserved
 
 


### PR DESCRIPTION
I noticed that the licence of this repository is not properly detected by GitHub. Hence the licence won't be displayed clearly at the top of the repository page (cf. [Detection of a license](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license)): 

> To have your license detected, simplify your LICENSE file and note the complexity somewhere else, such as your repository's README file

I leave it up to the reviewer/maintainer of this PR to decide whether or not relocating the copyright statements of Bosch and Bosch Manufacturing Solutions is a desirable solution. If so, I'm open for advice where to put them best.

**Before:** 
```bash
$ licensee detect --remote OpenManufacturingPlatform/sds-bamm-aspect-meta-model

License:        NOASSERTION
Matched files:  LICENSE.txt
LICENSE.txt:
  Content hash:  a1cdf26a2c3c1e38c9f6b654c0931a12189671fd
  License:       NOASSERTION
  Closest non-matching licenses:
    MPL-2.0 similarity:  97.10%
    EPL-2.0 similarity:  47.39%
    GPL-2.0 similarity:  43.43%
```

**After:**
```bash
$ licensee detect .

License:        MPL-2.0
Matched files:  LICENSE.txt
LICENSE.txt:
  Content hash:  3ac2de8040fbf1471d485f2571e74d17f2079e76
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MPL-2.0
```