### PR TITLE
[ADMIN] update license file based on Linux Foundation Legal Team

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,25 @@
-Mozilla Public License
-Version 2.0
+Materials in this repository other than source code are provided as follows:
+
+Copyright (c) 2021 Joint Development Foundation Projects, LLC, OMP Series and
+its contributors. All rights reserved. THESE MATERIALS ARE PROVIDED "AS IS." The
+parties expressly disclaim any warranties (express, implied, or otherwise),
+including implied warranties of merchantability, non-infringement, fitness for a
+particular purpose, or title, related to the materials. The entire risk as to
+implementing or otherwise using the materials is assumed by the implementer and
+user. IN NO EVENT WILL THE PARTIES BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS
+OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY
+CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE
+OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING
+NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The patent mode selected for materials developed by this Working Group is RAND
+Royalty-Free Mode. For specific details, see this Working Group's Charter at:
+
+https://open-manufacturing.org/wp-content/uploads/sites/101/2021/06/OMP-WG-Semantic-Data-Structuring-Charter-V4_0_1-9-Sep-2020.pdf
+
+Source code in this repository is provided under the Mozilla Public License 2.0, as follows:
+
 1. Definitions
 1.1. “Contributor”
 means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.


### PR DESCRIPTION
LF legal team has suggested to implement the following changes to the License in this repo.

Combine in one repository LICENSE.txt:

    the spec's copyright statement + disclaimer language
    the spec's patent licensing mode with a URL to the corresponding Working Group Charter
    the applicable license for any source code

Update the legal disclaimer inside acknowledgements:
Same as it is now the new proposal includes the corrected legal entity name for the copyright notice as well as referring to contributors.

Inside of the document, I don't find a legal disclaimer in the same way that e.g. https://github.com/OpenManufacturingPlatform/iotcon-connectivity-handbook/blob/update_license/White_Paper/01_Insights_Into_Connecting_Industrial_IoT_Assets/00_Acknowledgements.md#legal-disclaimers. 
It is a good practice to have this type of legal disclaimer in the document itself.

@BirgitBoss we can have a discussion about the content of this PR on our chairs meeting. I am providing the same changes to IoT Conn and MRA whitepapers.