### PR TITLE
Add Maven release workflow

### DIFF
--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -1,0 +1,35 @@
+name: Release Artifact
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version number of the release'
+        required: true
+jobs:
+  build-and-maven-release:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.1
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '11'
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build BAMM artifact and release to OSSRH
+      run: |
+        ./gradlew clean build
+        ./gradlew publishMavenReleasePublicationToMavenRepository
+      env:
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+        PGP_KEY: ${{ secrets.PGP_KEY }}
+        PGP_KEY_PASSWORD: ${{ secrets.PGP_KEY_PASSWORD }}
+        REPOSITORY_URL: ${{ secrets.REPOSITORY_URL }}
+    - name: Upload BAMM JAR
+      uses: actions/upload-artifact@v2
+      with:
+        name: bamm-artifacts
+        path: build/libs/

--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -7,6 +7,12 @@ on:
         required: true
 jobs:
   build-and-maven-release:
+    env:
+      OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+      PGP_KEY: ${{ secrets.PGP_KEY }}
+      PGP_KEY_PASSWORD: ${{ secrets.PGP_KEY_PASSWORD }}
+      REPOSITORY_URL: ${{ secrets.REPOSITORY_URL }}
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
@@ -22,12 +28,6 @@ jobs:
       run: |
         ./gradlew clean build
         ./gradlew publishMavenReleasePublicationToMavenRepository
-      env:
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-        PGP_KEY: ${{ secrets.PGP_KEY }}
-        PGP_KEY_PASSWORD: ${{ secrets.PGP_KEY_PASSWORD }}
-        REPOSITORY_URL: ${{ secrets.REPOSITORY_URL }}
     - name: Upload BAMM JAR
       uses: actions/upload-artifact@v2
       with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ publishing {
                 username = System.getenv("OSSRH_USERNAME")
                 password = System.getenv("OSSRH_TOKEN")
             }
-            var repositoryUrl : String? = System.getenv("REPOSITORY_URL")
+            var repositoryUrl : String? = System.getenv("REPOSITORY_URL") ?: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
             url = uri(repositoryUrl)
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,11 @@ plugins {
 group = "io.openmanufacturing"
 version = "1.0.0"
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 tasks.withType<JavaCompile> {
     sourceCompatibility = "11"
     targetCompatibility = "11"
@@ -43,13 +48,38 @@ publishing {
 
             pom {
                 name.set("BAMM Aspect Meta Model")
+                description.set("BAMM Aspect Meta Model")
+                url.set("https://openmanufacturingplatform.github.io/sds-bamm-aspect-meta-model/index.html")
                 licenses {
                     license {
                         name.set("Mozilla Public License, Version 2.0")
                         url.set("https://www.mozilla.org/en-US/MPL/2.0/")
                     }
                 }
+                scm {
+                    connection.set("scm:git:git://github.com:OpenManufacturingPlatform/sds-bamm-aspect-meta-model.git")
+                    developerConnection.set("scm:git:ssh://git@github.com:OpenManufacturingPlatform/sds-bamm-aspect-meta-model.git")
+                    url.set("https://github.com/OpenManufacturingPlatform/sds-bamm-aspect-meta-model")
+                }
+                developers {
+                    developer {
+                        name.set("Semantic Data Structuring Working Group")
+                        email.set("artifacts@open-manufacturing.org")
+                        organization.set("Open Manufacturing Platform")
+                        organizationUrl.set("https://open-manufacturing.org")
+                    }
+                }
             }
+        }
+    }
+    repositories {
+        maven {
+            credentials {
+                username = System.getenv("OSSRH_USERNAME")
+                password = System.getenv("OSSRH_TOKEN")
+            }
+            var repositoryUrl : String? = System.getenv("REPOSITORY_URL")
+            url = uri(repositoryUrl)
         }
     }
 }


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to build the BAMM JAR artifact and publish it via OSSRH to Maven Central. The workflow is triggered manually using the GitHub UI.