### PR TITLE
Fix declaration of operations: non-mandatory outputs

### DIFF
--- a/src/docs/modules/ROOT/pages/modeling-guidelines.adoc
+++ b/src/docs/modules/ROOT/pages/modeling-guidelines.adoc
@@ -521,7 +521,7 @@ Operations have the following attributes:
 | `bamm:input` | A list of references to Properties that describe the input to the operation. The
   attribute must be present, but the list may be empty. | {ok}
 | `bamm:output` | A single reference to a Property that describes the output of the operation. |
-  {ok}
+  {nok}
 |===
 
 Example:


### PR DESCRIPTION
Fixes #75.
As it is already defined both in the formal modal in in the model elements overview that operations have no mandatory output, this PR fixes the corresponding entry in the "Declaring Operations" section of the specification text.