### PR TITLE
Using characteristic samm-c:Either fails the resolver

### DIFF
--- a/documentation/modules/ROOT/pages/characteristics.adoc
+++ b/documentation/modules/ROOT/pages/characteristics.adoc
@@ -277,6 +277,8 @@ a `samm:dataType`, this must therefore be done when instantiating the Characteri
 Describes a Property whose value can have one of two possible types (a disjoint union).
 This Characteristic does not have one explicit `samm:dataType`, as it can be the datatype of either the left or the right.
 
+Important: A Property that uses an Either characteristic must not define an `exampleValue`. This is because the value type is ambiguous and depends on which side of the Either is used.
+
 See xref:modeling-guidelines.adoc#declaring-either[declaring either] for usage in an Aspect Model.
 
 [width="100%", options="header", cols="30,60,10"]

--- a/esmf-semantic-aspect-meta-model/src/main/resources/samm/characteristic/2.3.0/characteristic-shapes.ttl
+++ b/esmf-semantic-aspect-meta-model/src/main/resources/samm/characteristic/2.3.0/characteristic-shapes.ttl
@@ -738,6 +738,18 @@ samm-c:EitherShape
       sh:maxCount 0 ;
       sh:name "dataType" ;
       sh:description "An Either Characteristic may not define a data type. The data type is set by the Characteristics for the left and right side of the disjoint union." ;
+   ] ;
+   sh:sparql [
+     a sh:SPARQLConstraint ;
+     sh:message "Property '{?property}' uses an Either characteristic and must not define an exampleValue." ;
+     sh:prefixes samm:prefixDeclarations ;
+     sh:select """
+       select $this ?property 
+       where {
+         ?property samm:characteristic $this .
+         ?property samm:exampleValue ?exampleValue
+       }
+     """
    ] .
 
 samm-c:StructuredValueShape

--- a/esmf-semantic-aspect-meta-model/src/test/java/org/eclipse/esmf/samm/AbstractShapeTest.java
+++ b/esmf-semantic-aspect-meta-model/src/test/java/org/eclipse/esmf/samm/AbstractShapeTest.java
@@ -124,6 +124,7 @@ public abstract class AbstractShapeTest {
    final String messageValueDoesNotHaveNodeKindIri = "Value does not have node kind IRI";
    final String messageValueMustBeCharacteristic = "Value must be an instance of samm:Characteristic";
    final String messageMoreThanZeroValues = "Property may only have 0 values, but found 1";
+   final String messageCharacteristicMustNotDefineExampleValue = "Property ':speedProperty' uses an Either characteristic and must not define an exampleValue.";
    final String messageInvalidLowerBoundDefinitionValue = "Value must be exactly one of [samm-c:AT_LEAST, samm-c:GREATER_THAN]";
    final String messageInvalidUpperBoundDefinitionValue = "Value must be exactly one of [samm-c:LESS_THAN, samm-c:AT_MOST]";
    final String messageInvalidDeconstruction = "Deconstruction rule did not match Properties in elements";

--- a/esmf-semantic-aspect-meta-model/src/test/java/org/eclipse/esmf/samm/EitherShapeTest.java
+++ b/esmf-semantic-aspect-meta-model/src/test/java/org/eclipse/esmf/samm/EitherShapeTest.java
@@ -13,10 +13,10 @@
 
 package org.eclipse.esmf.samm;
 
+import org.eclipse.esmf.samm.validation.SemanticError;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import org.eclipse.esmf.samm.validation.SemanticError;
 
 public class EitherShapeTest extends AbstractShapeTest {
 
@@ -89,5 +89,14 @@ public class EitherShapeTest extends AbstractShapeTest {
             messageMoreThanZeroValues, focusNode, sammUrns.datatypeUrn, violationUrn, "" );
       expectSemanticValidationErrors( "either-shape", "TestEitherDefinesDataType",
             metaModelVersion, result );
+   }
+
+   @ParameterizedTest
+   @MethodSource( value = "versionsStartingWith2_3_0" )
+   public void testTestEitherExampleValueFailure( final KnownVersion metaModelVersion ) {
+      final SemanticError result = new SemanticError(
+            messageCharacteristicMustNotDefineExampleValue, testNamespacePrefix + "Result", "", violationUrn,
+            testNamespacePrefix + "Result" );
+      expectSemanticValidationErrors( "either-shape", "TestEitherExampleValue", metaModelVersion, result );
    }
 }

--- a/esmf-semantic-aspect-meta-model/src/test/resources/samm_2_3_0/either-shape/org.eclipse.esmf.test/1.0.0/TestEitherExampleValue.ttl
+++ b/esmf-semantic-aspect-meta-model/src/test/resources/samm_2_3_0/either-shape/org.eclipse.esmf.test/1.0.0/TestEitherExampleValue.ttl
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+#
+# See the AUTHORS file(s) distributed with this work for additional
+# information regarding authorship.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+@prefix : <urn:samm:org.eclipse.esmf.samm.test:1.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.3.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.3.0#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:speedProperty a samm:Property ;
+  samm:characteristic :Result ;
+  samm:exampleValue "This value must not be defined" .
+
+:Result a samm-c:Either ;
+  samm-c:left :ErrorMessage ;
+  samm-c:right :SpeedValue .
+
+:ErrorMessage a samm-c:SingleEntity ;
+  samm:dataType :ErrorEntity .
+
+:SpeedValue a samm-c:Quantifiable ;
+  samm:dataType xsd:integer .
+
+:ErrorEntity a samm:Entity ;
+   samm:properties (  ) .


### PR DESCRIPTION
## Description

Added validation to ensure that properties using the Either characteristic cannot define an exampleValue, and updated the documentation to reflect this rule.

Fixes [#837](https://github.com/eclipse-esmf/esmf-sdk/issues/837)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
