### PR TITLE
fix: blank node property in list validation

### DIFF
--- a/esmf-semantic-aspect-meta-model/src/main/resources/samm/meta-model/2.3.0/aspect-meta-model-shapes.ttl
+++ b/esmf-semantic-aspect-meta-model/src/main/resources/samm/meta-model/2.3.0/aspect-meta-model-shapes.ttl
@@ -681,7 +681,7 @@ samm:ValidEntityInstances
          select $this ?value ?path ?code ?highlight
          where {
            $this a ?entityType .
-           ?entityType samm:extends*/samm:properties/rdf:rest*/rdf:first ?property .
+           ?entityType samm:extends*/samm:properties/rdf:rest*/rdf:first/samm:property* ?property .
            ?property samm:characteristic/samm-c:baseCharacteristic*/samm:dataType ?characteristicDataType .
            $this ?property ?instanceValue .
            bind( datatype( ?instanceValue ) as ?providedType )

--- a/esmf-semantic-aspect-meta-model/src/test/java/org/eclipse/esmf/samm/ValidEntityInstancesShapeTest.java
+++ b/esmf-semantic-aspect-meta-model/src/test/java/org/eclipse/esmf/samm/ValidEntityInstancesShapeTest.java
@@ -64,6 +64,15 @@ public class ValidEntityInstancesShapeTest extends AbstractShapeTest {
    }
 
    @ParameterizedTest
+   @MethodSource( value = "versionsStartingWith2_3_0" )
+   public void testInvalidEntityInstanceWithInvalidPropertyLiteralExpectFailure( final KnownVersion metaModelVersion ) {
+      final SemanticError resultInvalidValueType = new SemanticError(
+            "The type of the value of the Property ':langTextProperty' of the Entity instance ':Instance' does not match the Property definition.",
+            focusNode, testNamespacePrefix + "langTextProperty", violationUrn, "undefined" );
+      expectSemanticValidationErrors( "valid-entity-instance-shape", "TestEntityInstanceInvalidPropertyLiteral", metaModelVersion , resultInvalidValueType);
+   }
+
+   @ParameterizedTest
    @MethodSource( value = "allVersions" )
    public void testMissingNotInPayloadPropertyExpectFailure( final KnownVersion metaModelVersion ) {
       final SemanticError validationError = getSingleSemanticValidationError(

--- a/esmf-semantic-aspect-meta-model/src/test/resources/samm_2_3_0/valid-entity-instance-shape/org.eclipse.esmf.test/1.0.0/TestEntityInstanceInvalidPropertyLiteral.ttl
+++ b/esmf-semantic-aspect-meta-model/src/test/resources/samm_2_3_0/valid-entity-instance-shape/org.eclipse.esmf.test/1.0.0/TestEntityInstanceInvalidPropertyLiteral.ttl
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+#
+# See the AUTHORS file(s) distributed with this work for additional
+# information regarding authorship.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+@prefix : <urn:samm:org.eclipse.esmf.samm.test:1.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.3.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.3.0#> .
+
+:TestEntityInstanceInvalidNotInPayloadValueType a samm:Aspect ;
+   samm:properties ( ) ;
+   samm:operations ( ) .
+
+:TestEnumeration a samm-c:Enumeration ;
+   samm:dataType :Entity ;
+   samm-c:values ( :Instance ) .
+
+:Entity a samm:Entity ;
+   samm:properties ( [ samm:property :langTextProperty; samm:notInPayload true ] :textProperty ) .
+
+:textProperty a samm:Property ;
+   samm:characteristic samm-c:Text .
+
+:langTextProperty a samm:Property ;
+   samm:characteristic samm-c:MultiLanguageText .
+
+:Instance a :Entity ;
+   :textProperty "foo" ;
+   :langTextProperty "undefined" .
+


### PR DESCRIPTION
## Description

Fix validation of blank node properties in lists

Fixes #379

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
    (not necessary IMO)
- [ ] I have made corresponding changes to the documentation
    (not necessary IMO)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:
\-
